### PR TITLE
include include :-)

### DIFF
--- a/orig/Makefile
+++ b/orig/Makefile
@@ -4,12 +4,13 @@
 #endif
 #ifeq ($(BLAS), OPENBLAS) 
 CC = g++
+INCL = -I/usr/include/openblas/
 LIBS = -lopenblas -L/shared/apps/rhel-6.2/libs/openblas-0.2.8/sandybridge/lib
 #endif
 
 
 test: test.cpp
-	$(CC) -g -o test test.cpp $(LIBS)
+	$(CC) -g -o test test.cpp $(INCL) $(LIBS)
 gemm_test: gemm_test.cpp
 	$(CC) -g -o gemm_test gemm_test.cpp $(LIBS)
 example-1: example-1.cpp


### PR DESCRIPTION
otherwise, it'll give:
g++ -g -o test test.cpp -lopenblas -L/shared/apps/rhel-6.2/libs/openblas-0.2.8/sandybridge/lib
test.cpp:6:10: fatal error: cblas.h: No such file or directory
 #include "cblas.h"